### PR TITLE
Add option to use exact palette colors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ License: GPL-3 | file LICENSE
 URL: https://github.com/nmfs-ost/nmfspalette
 BugReports: https://github.com/nmfs-ost/nmfspalette/issues
 Imports: 
+    cli,
     ggplot2
 Suggests: 
     dichromat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ URL: https://github.com/nmfs-ost/nmfspalette
 BugReports: https://github.com/nmfs-ost/nmfspalette/issues
 Imports: 
     cli,
-    ggplot2
+    ggplot2,
+    rlang
 Suggests: 
     dichromat,
     dplyr,

--- a/R/ggplot2-scales.R
+++ b/R/ggplot2-scales.R
@@ -44,8 +44,10 @@ scale_color_nmfs <- function(
       )
     } else {
       cli::cli_alert_info("The {palette} palette has {pal_length} colors.")
-      cli::cli_alert_info("An error will occur if there are too few palette colors for your plot.")
-      cli::cli_alert_info("To avoid this error, use a larger palette or `interpolate = TRUE`.")
+      rlang::warn(message = "An error will occur if there are too few palette colors for your plot.
+To avoid this error, use a larger palette or `interpolate = TRUE`.",
+                 .frequency = "once",
+                 .frequency_id = "too_few_colors_warning_color")
       ggplot2::scale_color_manual(
         values = nmfs_palette(palette)(pal_length),
         ...)
@@ -93,8 +95,10 @@ scale_fill_nmfs <- function(
       )
     } else {
       cli::cli_alert_info("The {palette} palette has {pal_length} colors.")
-      cli::cli_alert_info("An error will occur if there are too few palette colors for your plot.")
-      cli::cli_alert_info("To avoid this error, use a larger palette or `interpolate = TRUE`.")
+      rlang::warn(message = "An error will occur if there are too few palette colors for your plot.
+To avoid this error, use a larger palette or `interpolate = TRUE`.",
+                  .frequency = "once",
+                  .frequency_id = "too_few_colors_warning_fill")
       ggplot2::scale_fill_manual(
         values = nmfs_palette(palette)(pal_length),
         ...)

--- a/R/ggplot2-scales.R
+++ b/R/ggplot2-scales.R
@@ -9,20 +9,21 @@
 #' @param interpolate Boolean indicating whether the colors assigned to plot
 #' objects should interpolated from palettes, with the alternative that only the
 #' defined colors in the palette are used. Default is TRUE.
-#' @param ... Additional arguments passed to [ggplot2::discrete_scale()] or
-#'            [ggplot2::scale_color_gradientn()], used respectively when
-#'            `discrete` is TRUE or FALSE.
+#' @param ... Additional arguments passed to: [ggplot2::scale_color_gradientn()]
+#' when `discrete` is TRUE; [ggplot2::discrete_scale()] when `discrete` is FALSE
+#' and `interpolate` is TRUE; and [ggplot2::scale_color_manual()] when `discrete`
+#' is FALSE and `interpolate` is FALSE.
 #' @examples
 #' library(ggplot2)
 #' ggplot(iris, aes(Sepal.Width, Sepal.Length, color = Species)) +
 #'   geom_point(size = 4) +
 #'   scale_color_nmfs("coral")
 #'
-# ggplot(mtcars, aes(mpg, disp, color = as.factor(gear))) +
-#   geom_point(size = 4) +
-#   scale_color_nmfs("regional",
-#                    interpolate = FALSE,
-#                    discrete = TRUE)
+#' ggplot(mtcars, aes(mpg, disp, color = as.factor(gear))) +
+#'   geom_point(size = 4) +
+#'   scale_color_nmfs("regional",
+#'                    interpolate = FALSE,
+#'                    discrete = TRUE)
 #' @export
 scale_color_nmfs <- function(
     palette = "oceans",
@@ -42,8 +43,12 @@ scale_color_nmfs <- function(
         ...
       )
     } else {
+      cli::cli_alert_info("The {palette} palette has {pal_length} colors.")
+      cli::cli_alert_info("An error will occur if there are too few palette colors for your plot.")
+      cli::cli_alert_info("To avoid this error, use a larger palette or `interpolate = TRUE`.")
       ggplot2::scale_color_manual(
-        values = nmfs_palette(palette)(pal_length))
+        values = nmfs_palette(palette)(pal_length),
+        ...)
     }
   } else {
     ggplot2::scale_color_gradientn(colours = pal(256), ...)
@@ -51,36 +56,49 @@ scale_color_nmfs <- function(
 }
 
 #' Fill scale constructor for nmfs colors
-#'
-#' @param palette Character name of palette in `nmfs_palettes`. Default value
-#' is "oceans".
-#' @param discrete Boolean indicating whether color aesthetic is discrete.
-#' Default value is TRUE.
-#' @param reverse Boolean indicating whether the palette should be reversed.
-#' Default value is FALSE.
-#' @param ... Additional arguments passed to [ggplot2::discrete_scale()] or
-#'            [ggplot2::scale_fill_gradientn()], used respectively when
-#'            `discrete` is TRUE or FALSE.
+#' @inheritParams scale_color_nmfs
+#' @param ... Additional arguments passed to: [ggplot2::scale_fill_gradientn()]
+#' when `discrete` is TRUE; [ggplot2::discrete_scale()] when `discrete` is FALSE
+#' and `interpolate` is TRUE; and [ggplot2::scale_fill_manual()] when `discrete`
+#' is FALSE and `interpolate` is FALSE.
 #' @examples
 #' library(ggplot2)
 #' ggplot(mpg, aes(x = hwy, y = cty, fill = cyl)) +
 #'   geom_point(shape = 21) +
 #'   theme(axis.text.x = element_text(angle = 45, hjust = 1)) +
 #'   scale_fill_nmfs(palette = "crustacean", discrete = FALSE)
+#'
+#' ggplot(mtcars, aes(mpg, disp, color = as.factor(gear))) +
+#'   geom_point(size = 4) +
+#'   scale_fill_nmfs("regional",
+#'                    interpolate = FALSE,
+#'                    discrete = TRUE)
 #' @export
 scale_fill_nmfs <- function(
     palette = "oceans",
     discrete = TRUE,
     reverse = FALSE,
+    interpolate = TRUE,
     ...) {
   pal <- nmfs_palette(palette = palette, reverse = reverse)
 
+  pal_length <- length(nmfs_palettes[[palette]])
+
   if (discrete) {
-    ggplot2::discrete_scale(
-      aesthetics = "fill",
-      palette = pal,
-      ...
-    )
+    if (interpolate){
+      ggplot2::discrete_scale(
+        aesthetics = "fill",
+        palette = pal,
+        ...
+      )
+    } else {
+      cli::cli_alert_info("The {palette} palette has {pal_length} colors.")
+      cli::cli_alert_info("An error will occur if there are too few palette colors for your plot.")
+      cli::cli_alert_info("To avoid this error, use a larger palette or `interpolate = TRUE`.")
+      ggplot2::scale_fill_manual(
+        values = nmfs_palette(palette)(pal_length),
+        ...)
+    }
   } else {
     ggplot2::scale_fill_gradientn(colours = pal(256), ...)
   }

--- a/R/ggplot2-scales.R
+++ b/R/ggplot2-scales.R
@@ -6,6 +6,9 @@
 #' Default is TRUE.
 #' @param reverse Boolean indicating whether the palette should be reversed.
 #' Default is FALSE.
+#' @param interpolate Boolean indicating whether the colors assigned to plot
+#' objects should interpolated from palettes, with the alternative that only the
+#' defined colors in the palette are used. Default is TRUE.
 #' @param ... Additional arguments passed to [ggplot2::discrete_scale()] or
 #'            [ggplot2::scale_color_gradientn()], used respectively when
 #'            `discrete` is TRUE or FALSE.
@@ -14,20 +17,34 @@
 #' ggplot(iris, aes(Sepal.Width, Sepal.Length, color = Species)) +
 #'   geom_point(size = 4) +
 #'   scale_color_nmfs("coral")
+#'
+# ggplot(mtcars, aes(mpg, disp, color = as.factor(gear))) +
+#   geom_point(size = 4) +
+#   scale_color_nmfs("regional",
+#                    interpolate = FALSE,
+#                    discrete = TRUE)
 #' @export
 scale_color_nmfs <- function(
     palette = "oceans",
     discrete = TRUE,
     reverse = FALSE,
+    interpolate = TRUE,
     ...) {
   pal <- nmfs_palette(palette = palette, reverse = reverse)
 
+  pal_length <- length(nmfs_palettes[[palette]])
+
   if (discrete) {
-    ggplot2::discrete_scale(
-      aesthetics = "colour",
-      palette = pal,
-      ...
-    )
+    if (interpolate){
+      ggplot2::discrete_scale(
+        aesthetics = "colour",
+        palette = pal,
+        ...
+      )
+    } else {
+      ggplot2::scale_color_manual(
+        values = nmfs_palette(palette)(pal_length))
+    }
   } else {
     ggplot2::scale_color_gradientn(colours = pal(256), ...)
   }

--- a/man/scale_color_nmfs.Rd
+++ b/man/scale_color_nmfs.Rd
@@ -4,7 +4,13 @@
 \alias{scale_color_nmfs}
 \title{Color scale constructor for nmfs colors}
 \usage{
-scale_color_nmfs(palette = "oceans", discrete = TRUE, reverse = FALSE, ...)
+scale_color_nmfs(
+  palette = "oceans",
+  discrete = TRUE,
+  reverse = FALSE,
+  interpolate = TRUE,
+  ...
+)
 }
 \arguments{
 \item{palette}{Character name of palette in \code{nmfs_palettes}. Default value
@@ -15,6 +21,10 @@ Default is TRUE.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.
 Default is FALSE.}
+
+\item{interpolate}{Boolean indicating whether the colors assigned to plot
+objects should interpolated from palettes, with the alternative that only the
+defined colors in the palette are used. Default is TRUE.}
 
 \item{...}{Additional arguments passed to \code{\link[ggplot2:discrete_scale]{ggplot2::discrete_scale()}} or
 \code{\link[ggplot2:scale_gradient]{ggplot2::scale_color_gradientn()}}, used respectively when
@@ -28,4 +38,5 @@ library(ggplot2)
 ggplot(iris, aes(Sepal.Width, Sepal.Length, color = Species)) +
   geom_point(size = 4) +
   scale_color_nmfs("coral")
+
 }

--- a/man/scale_color_nmfs.Rd
+++ b/man/scale_color_nmfs.Rd
@@ -26,9 +26,10 @@ Default is FALSE.}
 objects should interpolated from palettes, with the alternative that only the
 defined colors in the palette are used. Default is TRUE.}
 
-\item{...}{Additional arguments passed to \code{\link[ggplot2:discrete_scale]{ggplot2::discrete_scale()}} or
-\code{\link[ggplot2:scale_gradient]{ggplot2::scale_color_gradientn()}}, used respectively when
-\code{discrete} is TRUE or FALSE.}
+\item{...}{Additional arguments passed to: \code{\link[ggplot2:scale_gradient]{ggplot2::scale_color_gradientn()}}
+when \code{discrete} is TRUE; \code{\link[ggplot2:discrete_scale]{ggplot2::discrete_scale()}} when \code{discrete} is FALSE
+and \code{interpolate} is TRUE; and \code{\link[ggplot2:scale_manual]{ggplot2::scale_color_manual()}} when \code{discrete}
+is FALSE and \code{interpolate} is FALSE.}
 }
 \description{
 Color scale constructor for nmfs colors
@@ -39,4 +40,9 @@ ggplot(iris, aes(Sepal.Width, Sepal.Length, color = Species)) +
   geom_point(size = 4) +
   scale_color_nmfs("coral")
 
+ggplot(mtcars, aes(mpg, disp, color = as.factor(gear))) +
+  geom_point(size = 4) +
+  scale_color_nmfs("regional",
+                   interpolate = FALSE,
+                   discrete = TRUE)
 }

--- a/man/scale_fill_nmfs.Rd
+++ b/man/scale_fill_nmfs.Rd
@@ -4,21 +4,32 @@
 \alias{scale_fill_nmfs}
 \title{Fill scale constructor for nmfs colors}
 \usage{
-scale_fill_nmfs(palette = "oceans", discrete = TRUE, reverse = FALSE, ...)
+scale_fill_nmfs(
+  palette = "oceans",
+  discrete = TRUE,
+  reverse = FALSE,
+  interpolate = TRUE,
+  ...
+)
 }
 \arguments{
 \item{palette}{Character name of palette in \code{nmfs_palettes}. Default value
 is "oceans".}
 
 \item{discrete}{Boolean indicating whether color aesthetic is discrete.
-Default value is TRUE.}
+Default is TRUE.}
 
 \item{reverse}{Boolean indicating whether the palette should be reversed.
-Default value is FALSE.}
+Default is FALSE.}
 
-\item{...}{Additional arguments passed to \code{\link[ggplot2:discrete_scale]{ggplot2::discrete_scale()}} or
-\code{\link[ggplot2:scale_gradient]{ggplot2::scale_fill_gradientn()}}, used respectively when
-\code{discrete} is TRUE or FALSE.}
+\item{interpolate}{Boolean indicating whether the colors assigned to plot
+objects should interpolated from palettes, with the alternative that only the
+defined colors in the palette are used. Default is TRUE.}
+
+\item{...}{Additional arguments passed to: \code{\link[ggplot2:scale_gradient]{ggplot2::scale_fill_gradientn()}}
+when \code{discrete} is TRUE; \code{\link[ggplot2:discrete_scale]{ggplot2::discrete_scale()}} when \code{discrete} is FALSE
+and \code{interpolate} is TRUE; and \code{\link[ggplot2:scale_manual]{ggplot2::scale_fill_manual()}} when \code{discrete}
+is FALSE and \code{interpolate} is FALSE.}
 }
 \description{
 Fill scale constructor for nmfs colors
@@ -29,4 +40,10 @@ ggplot(mpg, aes(x = hwy, y = cty, fill = cyl)) +
   geom_point(shape = 21) +
   theme(axis.text.x = element_text(angle = 45, hjust = 1)) +
   scale_fill_nmfs(palette = "crustacean", discrete = FALSE)
+
+ggplot(mtcars, aes(mpg, disp, color = as.factor(gear))) +
+  geom_point(size = 4) +
+  scale_fill_nmfs("regional",
+                   interpolate = FALSE,
+                   discrete = TRUE)
 }

--- a/tests/testthat/_snaps/scale-fill/scale-fill-nmfs-discrete-t-interp-f.svg
+++ b/tests/testthat/_snaps/scale-fill/scale-fill-nmfs-discrete-t-interp-f.svg
@@ -1,0 +1,307 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzIuNzl8NjQwLjU5fDIyLjc4fDU0NS4xMQ=='>
+    <rect x='32.79' y='22.78' width='607.80' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNzl8NjQwLjU5fDIyLjc4fDU0NS4xMQ==)'>
+<rect x='32.79' y='22.78' width='607.80' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='57.27' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='317.32' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='333.54' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='57.27' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='317.32' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='609.81' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='463.43' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='280.80' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='57.27' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='609.81' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='518.22' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='333.54' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='518.22' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='463.43' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='518.22' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='463.43' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='518.22' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='463.43' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='333.54' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='333.54' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='609.81' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='57.27' y='171.22' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='244.27' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='226.01' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='262.53' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='244.27' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='207.74' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='226.01' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='244.27' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='317.32' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='317.32' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='609.81' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='518.22' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='463.43' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='463.43' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='463.43' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='333.54' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='262.53' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='262.53' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='333.54' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='609.81' y='463.43' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='609.81' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='57.27' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='317.32' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='317.32' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='317.32' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='317.32' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='317.32' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='609.81' y='426.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='280.80' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='57.27' y='244.27' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='244.27' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='207.74' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='171.22' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='207.74' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='609.81' y='481.69' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='609.81' y='445.17' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<rect x='57.27' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='408.64' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='280.80' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='57.27' y='79.90' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='280.80' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='195.41' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #5EB6D9;' />
+<rect x='195.41' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #5EB6D9;' />
+<rect x='333.54' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='57.27' y='43.37' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='152.95' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='195.41' y='317.32' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #5EB6D9;' />
+<rect x='195.41' y='317.32' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #5EB6D9;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='335.59' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='57.27' y='299.06' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='333.54' y='390.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='353.85' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='333.54' y='372.11' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='32.79' y='22.78' width='607.80' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.86' y='506.14' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='27.86' y='414.82' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='27.86' y='323.50' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='27.86' y='232.19' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='27.86' y='140.87' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='27.86' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<polyline points='30.05,503.11 32.79,503.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,411.79 32.79,411.79 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,320.47 32.79,320.47 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,229.16 32.79,229.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,137.84 32.79,137.84 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,46.53 32.79,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='60.42,547.85 60.42,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='198.56,547.85 198.56,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='336.69,547.85 336.69,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='474.83,547.85 474.83,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='612.96,547.85 612.96,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='60.42' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='198.56' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='336.69' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='474.83' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='612.96' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='336.69' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='13.45px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='14.06px' lengthAdjust='spacingAndGlyphs'>cty</text>
+<rect x='651.55' y='241.72' width='62.97' height='84.45' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='651.55' y='250.43' style='font-size: 11.00px; font-family: sans;' textLength='62.97px' lengthAdjust='spacingAndGlyphs'>as.factor(cyl)</text>
+<rect x='651.55' y='257.05' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='657.04' y='262.54' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #C6E6F0;' />
+<rect x='651.55' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='657.04' y='279.82' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #5EB6D9;' />
+<rect x='651.55' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='657.04' y='297.10' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #0085CA;' />
+<rect x='651.55' y='308.89' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='657.04' y='314.38' width='6.30' height='6.30' style='stroke-width: 0.71; fill: #003087;' />
+<text x='674.31' y='268.72' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='674.31' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='674.31' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='674.31' y='320.56' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='212.75px' lengthAdjust='spacingAndGlyphs'>scale_fill_nmfs - discrete T - interp F</text>
+</g>
+</svg>

--- a/tests/testthat/test-scale-fill.R
+++ b/tests/testthat/test-scale-fill.R
@@ -7,16 +7,41 @@ test_that("nmfs_cols creates a valid plot", {
   )
 })
 
-p_discrete <- ggplot(mpg, aes(manufacturer, fill = manufacturer)) +
+p_discrete_interp <- ggplot(mpg, aes(manufacturer, fill = manufacturer)) +
   geom_bar() +
   theme(axis.text.x = element_text(angle = 45, hjust = 1)) +
-  scale_fill_nmfs(palette = "oceans", discrete = TRUE)
+  scale_fill_nmfs(palette = "oceans",
+                  discrete = TRUE,
+                  interpolate = TRUE)
 
 test_that("scale_fill works with discrete = TRUE", {
   skip_on_cran()
   skip_on_ci()
   vdiffr::expect_doppelganger(
     "scale_fill_nmfs with discrete = TRUE",
+    p_discrete_interp
+  )
+
+  expect_s3_class(
+    object = scale_color_nmfs(discrete = FALSE),
+    class = "ScaleContinuous"
+  )
+})
+
+p_discrete <- ggplot(mpg, aes(x = cyl,
+                              y = cty,
+                              fill = as.factor(cyl))) +
+  geom_point(shape = 22,
+             size = 3) +
+  scale_fill_nmfs(palette = "oceans",
+                  discrete = TRUE,
+                  interpolate = FALSE)
+
+test_that("scale_fill works with discrete = TRUE and interpolate = FALSE", {
+  skip_on_cran()
+  skip_on_ci()
+  vdiffr::expect_doppelganger(
+    "scale_fill_nmfs - discrete T - interp F",
     p_discrete
   )
 


### PR DESCRIPTION
Add option to use specific colors from nmfspalette palettes, as opposed to the default behavior (interpolation), for scale_color_nmfs; update documentation

Inspiration/credit for the feature: https://github.com/nmfs-ost/nmfspalette/issues/36

- [x] Draft feature for color
- [x] Draft feature for fill